### PR TITLE
Include stdexcept instead of exception

### DIFF
--- a/include/LuaGlue/LuaGlueObject.h
+++ b/include/LuaGlue/LuaGlueObject.h
@@ -2,7 +2,7 @@
 #define LUAGLUE_OBJECT_BASE_H_GUARD
 
 #include <atomic>
-#include <exception>
+#include <stdexcept>
 
 #include "LuaGlue/LuaGlueDebug.h"
 


### PR DESCRIPTION
On gcc version 4.7.3 (Ubuntu/Linaro 4.7.3-1ubuntu1), it needed the definition of std::runtime_error available when LuaGlueObject.h is included.
